### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/src/services/codeGenerator.ts
+++ b/src/services/codeGenerator.ts
@@ -603,7 +603,7 @@ ${this.objectToYaml(yamlConfig)}
     
     const frameworkDeps = {
       'crewai': ['crewai>=0.1.0', 'langchain>=0.1.0'],
-      'autogen': ['pyautogen>=0.2.0'],
+      'autogen': ['ag2>=0.2.0'],
       'google-adk': ['google-adk>=1.0.0', 'google-cloud>=0.34.0'],
     };
     
@@ -835,7 +835,7 @@ For platform-specific issues, contact the Multiagent Development Platform suppor
   private getFrameworkDependencies(framework: string): string[] {
     const deps = {
       'crewai': ['crewai', 'langchain', 'google-generativeai'],
-      'autogen': ['pyautogen', 'google-generativeai'],
+      'autogen': ['ag2', 'google-generativeai'],
       'google-adk': ['google-adk', 'google-cloud', 'google-generativeai'],
     };
     


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
